### PR TITLE
Allow parsing `.cjs` files as javascript

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -61,6 +61,14 @@ module.exports = {
 		expect: 'basic.import.expect.css',
 		result: 'basic.import.result.css'
 	},
+	'basic:import-cjs': {
+		message: 'supports { importFrom: "test/import-variables.cjs" } usage',
+		options: {
+			importFrom: 'test/import-variables.cjs'
+		},
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
 	'basic:import-js-from': {
 		message: 'supports { importFrom: { from: "test/import-variables.js" } } usage',
 		options: {

--- a/src/lib/import-from.js
+++ b/src/lib/import-from.js
@@ -73,7 +73,7 @@ export default function importEnvironmentVariablesFromSources(sources) {
 	}).reduce(async (environmentVariables, source) => {
 		const { type, from } = await source;
 
-		if (type === 'js') {
+		if (type === 'js' || type === 'cjs') {
 			return Object.assign(environmentVariables, await importEnvironmentVariablesFromJSFile(from));
 		}
 

--- a/test/import-variables.cjs
+++ b/test/import-variables.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+	environmentVariables: {
+		'--some-custom-padding': '20px',
+		'--another-custom-width': '600px'
+	}
+};


### PR DESCRIPTION
My snowpack project is set to `"type": "module"`, and so I need to use `.cjs` files for anything that's commonjs, such as my `postcss.config.cjs`.  I found that this plugin was not finding my environment variable file that also uses the `.cjs` extension.  

After looking at the tests, I see that I can use a `type: 'js'` in my options, but that's not obvious from the readme, and I think it's not a necessary workaround.  This PR treats `.cjs` files the same way as `.js`, which seems to work fine as far as I can tell.